### PR TITLE
Mitigate race condition in setting row expiry time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - "9.4"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal


### PR DESCRIPTION
Due to a race condition where the row (whose expiry is to be updated) is cleaned up by the cleanup thread, the expiry setting returns an exception.

To mitigate this, if the row doesnt exist, we set the usage to 1 and then set the expiry.